### PR TITLE
Turned off no underscore dangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2800,21 +2800,6 @@ Other Style Guides
     });
     ```
 
-  <a name="naming--leading-underscore"></a><a name="22.4"></a>
-  - [23.4](#naming--leading-underscore) Do not use trailing or leading underscores. eslint: [`no-underscore-dangle`](http://eslint.org/docs/rules/no-underscore-dangle.html) jscs: [`disallowDanglingUnderscores`](http://jscs.info/rule/disallowDanglingUnderscores)
-
-    > Why? JavaScript does not have the concept of privacy in terms of properties or methods. Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won’t count as breaking, or that tests aren’t needed. tl;dr: if you want something to be “private”, it must not be observably present.
-
-    ```javascript
-    // bad
-    this.__firstName__ = 'Panda';
-    this.firstName_ = 'Panda';
-    this._firstName = 'Panda';
-
-    // good
-    this.firstName = 'Panda';
-    ```
-
   <a name="naming--self-this"></a><a name="22.5"></a>
   - [23.5](#naming--self-this) Don’t save references to `this`. Use arrow functions or [Function#bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind). jscs: [`disallowNodeTypes`](http://jscs.info/rule/disallowNodeTypes)
 

--- a/packages/eslint-config-base/README.md
+++ b/packages/eslint-config-base/README.md
@@ -1,29 +1,29 @@
 # eslint-config-airbnb-base
 
-[![npm version](https://badge.fury.io/js/eslint-config-airbnb-base.svg)](http://badge.fury.io/js/eslint-config-airbnb-base)
+[![npm version](https://badge.fury.io/js/%40postmates%2Feslint-config-base.svg)](https://badge.fury.io/js/%40postmates%2Feslint-config-base)
 
-This package provides Airbnb's base JS .eslintrc (without React plugins) as an extensible shared config.
+This package provides Postmates' base JS .eslintrc (without React plugins) as an extensible shared config.
 
 ## Usage
 
 We export two ESLint configurations for your usage.
 
-### eslint-config-airbnb-base
+### @postmates/eslint-config-base
 
 Our default export contains all of our ESLint rules, including ECMAScript 6+. It requires `eslint` and `eslint-plugin-import`.
 
-If you use yarn, run `yarn add --dev eslint-config-airbnb-base eslint-plugin-import`, or see below for npm instructions.
+If you use yarn, run `yarn add --dev @postmates/eslint-config-base eslint-plugin-import`, or see below for npm instructions.
 
 1. Install the correct versions of each package, which are listed by the command:
 
   ```sh
-  npm info "eslint-config-airbnb-base@latest" peerDependencies
+  npm info "@postmates/eslint-config-base@latest" peerDependencies
   ```
 
   Linux/OSX users can run
   ```sh
   (
-    export PKG=eslint-config-airbnb-base;
+    export PKG=@postmates/eslint-config-base;
     npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG@latest"
   )
   ```
@@ -31,38 +31,38 @@ If you use yarn, run `yarn add --dev eslint-config-airbnb-base eslint-plugin-imp
   Which produces and runs a command like:
 
   ```sh
-    npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
+    npm install --save-dev @postmates/eslint-config-base eslint@^#.#.# eslint-plugin-import@^#.#.#
   ```
 
   Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
 
   ```sh
   npm install -g install-peerdeps
-  install-peerdeps --dev eslint-config-airbnb-base
+  install-peerdeps --dev @postmates/eslint-config-base
   ```
 
   The cli will produce and run a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb-base eslint@^#.#.# eslint-plugin-import@^#.#.#
+  npm install --save-dev @postmates/eslint-config-base eslint@^#.#.# eslint-plugin-import@^#.#.#
   ```
 
-2. Add `"extends": "airbnb-base"` to your .eslintrc.
+2. Add `"extends": "@postmates/eslint-config-base"` to your .eslintrc.
 
-### eslint-config-airbnb-base/legacy
+### @postmates/eslint-config-base/legacy
 
 Lints ES5 and below. Requires `eslint` and `eslint-plugin-import`.
 
 1. Install the correct versions of each package, which are listed by the command:
 
   ```sh
-  npm info "eslint-config-airbnb-base@latest" peerDependencies
+  npm info "@postmates/eslint-config-base@latest" peerDependencies
   ```
 
   Linux/OSX users can run
   ```sh
   (
-    export PKG=eslint-config-airbnb-base;
+    export PKG=@postmates/eslint-config-base;
     npm info "$PKG" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG"
   )
   ```
@@ -70,12 +70,12 @@ Lints ES5 and below. Requires `eslint` and `eslint-plugin-import`.
   Which produces and runs a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb-base eslint@^3.0.1 eslint-plugin-import@^1.10.3
+  npm install --save-dev @postmates/eslint-config-base eslint@^3.0.1 eslint-plugin-import@^1.10.3
   ```
 
-2. Add `"extends": "airbnb-base/legacy"` to your .eslintrc
+2. Add `"extends": "@postmates/eslint-config-base/legacy"` to your .eslintrc
 
-See [Airbnb's overarching ESLint config](https://npmjs.com/eslint-config-airbnb), [Airbnb's Javascript styleguide](https://github.com/airbnb/javascript), and the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information.
+See [Postmates' overarching ESLint config](https://npmjs.com/@postmates/eslint-config), [Postmates' Javascript styleguide](https://github.com/postmates/javascript), and the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information.
 
 ## Improving this config
 

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postmates/eslint-config-base",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Postmates' base JS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-base/rules/style.js
+++ b/packages/eslint-config-base/rules/style.js
@@ -300,12 +300,7 @@ module.exports = {
     }],
 
     // disallow dangling underscores in identifiers
-    'no-underscore-dangle': ['error', {
-      allow: [],
-      allowAfterThis: false,
-      allowAfterSuper: false,
-      // enforceInMethodNames: false, // TODO: uncoment and enable, semver-minor once v3 is dropped
-    }],
+    'no-underscore-dangle': 'off',
 
     // disallow the use of Boolean literals in conditional expressions
     // also, prefer `a || b` over `a ? a : b`


### PR DESCRIPTION
Updated the README, Turned off no underscore dangle because we use underscore dangle heavily.  Prepped the base for `1.0.0`