### PR TITLE
Require a key for iterators and arrays in jsx

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,30 +1,30 @@
-# eslint-config-airbnb
+ @postmates/eslint-config
 
-[![npm version](https://badge.fury.io/js/eslint-config-airbnb.svg)](http://badge.fury.io/js/eslint-config-airbnb)
+[![npm version](https://badge.fury.io/js/%40postmates%2Feslint-config.svg)](https://badge.fury.io/js/%40postmates%2Feslint-config)
 
-This package provides Airbnb's .eslintrc as an extensible shared config.
+This package provides Postmates' .eslintrc as an extensible shared config.
 
 ## Usage
 
 We export three ESLint configurations for your usage.
 
-### eslint-config-airbnb
+### @postmates/eslint-config
 
-Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+Our default export contains all of our ESLint rules, including ECMAScript 6+ and React. It requires `eslint`, `eslint-plugin-import`, `eslint-plugin-react`, and `eslint-plugin-jsx-a11y`. If you don't need React, see [@postmates/eslint-config-base](https://www.npmjs.com/@postmates/eslint-config-base).
 
-If you use yarn, run `yarn add --dev eslint-config-airbnb-base eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y`, and see below for npm instructions.
+If you use yarn, run `yarn add --dev @postmates/eslint-config eslint-plugin-import eslint-plugin-react eslint-plugin-jsx-a11y`, and see below for npm instructions.
 
 1. Install the correct versions of each package, which are listed by the command:
 
   ```sh
-  npm info "eslint-config-airbnb@latest" peerDependencies
+  npm info "@postmates/eslint-config@latest" peerDependencies
   ```
 
   Linux/OSX users can run
 
   ```sh
   (
-    export PKG=eslint-config-airbnb;
+    export PKG=@postmates/eslint-config;
     npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG@latest"
   )
   ```
@@ -32,33 +32,33 @@ If you use yarn, run `yarn add --dev eslint-config-airbnb-base eslint-plugin-imp
   Which produces and runs a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
+  npm install --save-dev @postmates/eslint-config eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
   ```
 
   Windows users can either install all the peer dependencies manually, or use the [install-peerdeps](https://github.com/nathanhleung/install-peerdeps) cli tool.
 
   ```sh
   npm install -g install-peerdeps
-  install-peerdeps --dev eslint-config-airbnb
+  install-peerdeps --dev @postmates/eslint-config
   ```
 
   The cli will produce and run a command like:
 
   ```sh
-  npm install --save-dev eslint-config-airbnb eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
+  npm install --save-dev @postmates/eslint-config eslint@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
   ```
 
-2. Add `"extends": "airbnb"` to your .eslintrc
+2. Add `"extends": "@postmates"` to your .eslintrc
 
 ### eslint-config-airbnb/base
 
-This entry point is deprecated. See [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+This entry point is deprecated. See [@postmates/eslint-config-base](https://npmjs.com/@postmates/eslint-config-base).
 
 ### eslint-config-airbnb/legacy
 
-This entry point is deprecated. See [eslint-config-airbnb-base](https://npmjs.com/eslint-config-airbnb-base).
+This entry point is deprecated. See [@postmates/eslint-config-base](https://npmjs.com/@postmates/eslint-config-base).
 
-See [Airbnb's Javascript styleguide](https://github.com/airbnb/javascript) and
+See [Postmates' Javascript styleguide](https://github.com/postmates/javascript) and
 the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)
 for more information.
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/postmates/javascript",
   "dependencies": {
-    "@postmates/eslint-config-base": "^0.0.1"
+    "@postmates/eslint-config-base": "^1.0.0"
   },
   "devDependencies": {
     "babel-preset-airbnb": "^2.4.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postmates/eslint-config",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Postmates' ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -70,7 +70,7 @@ module.exports = {
 
     // Validate JSX has key prop when in array or iterator
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
-    'react/jsx-key': 'off',
+    'react/jsx-key': 'error',
 
     // Limit maximum of props on a single line in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md

--- a/react/README.md
+++ b/react/README.md
@@ -324,6 +324,20 @@
   <div />
   ```
 
+  - Always include a `key` prop on elements when in an array or iterator. eslint: [`react/jsx-key`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)
+
+  ```jsx
+  // bad
+  [<Hello />, <Hello />, <Hello />];
+
+  data.map(({ name }) => <Hello>name</Hello>);
+
+  // good
+  [<Hello key="first" />, <Hello key="second" />, <Hello key="third" />];
+
+  data.map(({ id, name }) => <Hello key={id}>name</Hello>);
+  ```
+
   - Avoid using an array index as `key` prop, prefer a unique ID if possible. ([why?](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318))
 
   ```jsx


### PR DESCRIPTION
Updated the README, Require key props for arrays and iterators. Prepped the regular config for `1.0.0`